### PR TITLE
Replace structtag library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.2
 
 require (
-	github.com/fatih/structtag v1.2.0
+	github.com/alfatraining/structtag v1.0.0
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/tools v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
+github.com/alfatraining/structtag v1.0.0 h1:2qmcUqNcCoyVJ0up879K614L9PazjBSFruTB0GOFjCc=
+github.com/alfatraining/structtag v1.0.0/go.mod h1:p3Xi5SwzTi+Ryj64DqjLWz7XurHxbGsq6y3ubePJPus=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
-github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/tagalign.go
+++ b/tagalign.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/fatih/structtag"
+	"github.com/alfatraining/structtag"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/tagalign_test.go
+++ b/tagalign_test.go
@@ -3,7 +3,7 @@ package tagalign
 import (
 	"testing"
 
-	"github.com/fatih/structtag"
+	"github.com/alfatraining/structtag"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/tools/go/analysis/analysistest"
 )


### PR DESCRIPTION
Fixes #19.

I realized that the [`fatih/structtag`](https://github.com/fatih/structtag) library used in this project has some functionality that is not needed for `tagalign` and that can even cause problems. More specifically, it parses the individual `Options` of a struct tag (e.g., `omitempty` for `json:"foo,omitempty"`) whilst for `tagalign` it is sufficient to treat the value of a struct tag as a blob.

One example of where this additional parsing caused problems could be found in #19.

This PR changes the used `structtag` library to [`alfatraining/structtag`](https://github.com/alfatraining/structtag), a fork carefully crafted to support exactly the features `tagalign` requires and simplifying the handling of struct values. Given that `fatih/structtag` hasn't received any updates since almost three years (with some open MRs unmerged since 2021/22), I hope this change is acceptable. As you can see in this MR, apart from the import change, there is no change required to the `tagalign` code.